### PR TITLE
Support for nicknames in results

### DIFF
--- a/enwiki/tables/results/results_table.py
+++ b/enwiki/tables/results/results_table.py
@@ -262,7 +262,7 @@ def print_qualifying_table(championship: Championship, filepath: str, wiki_id: i
 			for x in range(1, 5):  # type: int
 				if (
 					row[f'DRIVER{x}_FIRSTNAME'] is None
-					or row[f'DRIVER{x}_FIRSTNAME'] == ''
+					or row[f'DRIVER{x}_FIRSTNAME'] == '' and row[f'DRIVER{x}_SECONDNAME'] == ''
 				):
 					continue
 
@@ -275,7 +275,7 @@ def print_qualifying_table(championship: Championship, filepath: str, wiki_id: i
 
 				if driver_data is None or driver_data.empty_fields():
 					driver_data = Driver(
-						short_link=driver_name,
+						short_link=driver_name.strip(),
 						nationality=row[f'DRIVER{x}_COUNTRY']
 					)
 

--- a/enwiki/tables/results/results_table.py
+++ b/enwiki/tables/results/results_table.py
@@ -121,9 +121,15 @@ def print_race_table(championship: Championship, filepath: str, wiki_id: int) ->
 
 					if driver_data is None or driver_data.empty_fields():
 						driver_name = driver_codename.split(' ', 1)
+
+						driver_short_link = driver_name[0]
+
+						if len(driver_name) > 1:
+							driver_short_link += f' {driver_name[1].capitalize()}'
+
 						driver_data = Driver(
 							nationality='?',
-							short_link=f'{driver_name[0]} {driver_name[1].capitalize()}'
+							short_link=driver_short_link
 						)
 
 					drivers.append(driver_data)

--- a/plwiki/tabele/wyniki/tabela_wynikow.py
+++ b/plwiki/tabele/wyniki/tabela_wynikow.py
@@ -119,9 +119,15 @@ def print_race_table(championship: Championship, filepath: str, wiki_id: int) ->
 
 					if driver_data is None or driver_data.empty_fields():
 						driver_name = driver_codename.split(' ', 1)
+
+						driver_short_link = driver_name[0]
+
+						if len(driver_name) > 1:
+							driver_short_link += f' {driver_name[1].capitalize()}'
+
 						driver_data = Driver(
 							nationality='?',
-							short_link=f'[[{driver_name[0]} {driver_name[1].capitalize()}]]'
+							short_link=driver_short_link
 						)
 
 					drivers.append(driver_data)

--- a/plwiki/tabele/wyniki/tabela_wynikow.py
+++ b/plwiki/tabele/wyniki/tabela_wynikow.py
@@ -255,7 +255,7 @@ def print_qualifying_table(championship: Championship, filepath: str, wiki_id: i
 			for x in range(1, 5):  # type: int
 				if (
 					row[f'DRIVER{x}_FIRSTNAME'] is None
-					or row[f'DRIVER{x}_FIRSTNAME'] == ''
+					or row[f'DRIVER{x}_FIRSTNAME'] == '' and row[f'DRIVER{x}_SECONDNAME'] == ''
 				):
 					continue
 
@@ -268,7 +268,7 @@ def print_qualifying_table(championship: Championship, filepath: str, wiki_id: i
 
 				if driver_data is None or driver_data.empty_fields():
 					driver_data = Driver(
-						short_link=driver_name,
+						short_link=driver_name.strip(),
 						nationality=row[f'DRIVER{x}_COUNTRY']
 					)
 


### PR DESCRIPTION
2024/2025 Asian LMS season shows that ACO allows drivers to use nicknames instead of forenames and surnames. Changes in code reflect that, functions responsible for printing qualifying and race results are now able to handle drivers' nicknames.